### PR TITLE
Fix Yahoo

### DIFF
--- a/click2load.txt
+++ b/click2load.txt
@@ -1,15 +1,15 @@
 ! Title: ⛔ click2load filters
 ! Description: To be used in conjunction with other Annoyances lists
-! Updated: 15 August 2022
+! Updated: 7 October 2022
 ! License: https://creativecommons.org/licenses/by/3.0/
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires 4 days
 
 ! https://raw.githubusercontent.com/llacb47/miscfilters/master/clicktoload.txt
 ! https://twitter.com/gorhill/status/1377929952637640705
-||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com
-||youtube-nocookie.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com
-||player.vimeo.com/video^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com
+||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
+||youtube-nocookie.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
+||player.vimeo.com/video^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ||volume.vox-cdn.com/embed/$3p,frame,redirect=click2load.html
 ||scribd.com/embeds/$3p,frame,redirect=click2load.html
 ||docs.google.com/document/d/e/$3p,frame,redirect=click2load.html


### PR DESCRIPTION
With click2load filters, Yahoo fails to load YouTube videos:
![image](https://user-images.githubusercontent.com/84232764/194538734-f6296817-680b-4b49-9363-22b570c100a4.png)

Test page: `https://video.search.yahoo.com/search/video;_ylt=Awrih0OxBkBjEW0Oa0tXNyoA;_ylu=Y29sbwNiZjEEcG9zAzEEdnRpZAMEc2VjA3BpdnM-?p=ublock+origin&fr2=piv-web&fr=yfp-t#id=1&vid=4a6b9ca538c7b8a0753fcf74e65ace24&action=view` (some uBlock Origin tutorial)

Steps to reproduce:
- Go to yahoo.com
- Search for something likely to have videos
- On the results page, click "Videos"
- Chose any video, and try to play it
- The embed is blocked and the "Click to load" page is shown.



<details>
<summary>Filterlists</summary>
<img src="https://user-images.githubusercontent.com/84232764/194549275-26498601-f50a-47ad-b6c1-21982e46c89e.png">
<img src="https://user-images.githubusercontent.com/84232764/194549406-d9d7a704-69d4-4d39-8e66-68f7a4f4dff2.png">
</details>