### PR TITLE
nsverify.shop

### DIFF
--- a/enhanced_site_protection.txt
+++ b/enhanced_site_protection.txt
@@ -34,7 +34,7 @@
 ||quest^$doc
 ||rest^$doc
 ||review^$doc
-||shop^$doc
+||shop^$doc,domain=~nsverify.shop
 ||surf^$doc
 ||tk^$doc,domain=~coolcmd.tk|~budterence.tk|~google.tk|~transportnews.tk|~c0d3c.tk|~anonytext.tk|~tokelau-info.tk|~fakaofo.tk|~loljp-wiki.tk|~ninetail.tk|~goshujin.tk|~graph.tk|~dls2.pokeacer.tk|~nolfrevival.tk|~coppersurfer.tk|~restricted-functions.tk|~bstweaker.tk|~nbd-media.tk|~glypx-pakhsh-nakon.tk|~gotofap.tk|~somepythonthings.tk
 ||tokyo^$doc


### PR DESCRIPTION
I was using a Discord verification bot and the verification page was blocked.
Discord bot invite link: `https://discord.com/api/oauth2/authorize?client_id=1014100705763659817&permissions=8&scope=applications.commands%20bot` (I think only the owner can configure the bot)
the message from the bot

![image](https://user-images.githubusercontent.com/96731476/203326230-a22dbaee-ea38-4924-8f6f-ae708cdf6160.png)
