### PR TITLE
discohook.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Add the functionality of [ClearURLs](https://github.com/ClearURLs/Addon#-clearur
 2) **[Browse websites without logging in](https://github.com/DandelionSprout/adfilt/blob/master/BrowseWebsitesWithoutLoggingIn.txt)** | [add](https://raw.githubusercontent.com/DandelionSprout/adfilt/master/BrowseWebsitesWithoutLoggingIn.txt)
 <br> [optional]
 
-3) **[Anti-paywall filters](https://github.com/liamengland1/miscfilters/blob/master/antipaywall.txt)** | [add](https://raw.githubusercontent.com/llacb47/miscfilters/master/antipaywall.txt)
+3) **[Anti-paywall filters](https://github.com/liamengland1/miscfilters/blob/master/antipaywall.txt)** | [add](https://raw.githubusercontent.com/liamengland1/miscfilters/master/antipaywall.txt)
  <br> [optional] This list blocks additional third-party requests and annoyances that are not covered in the `Bypass Paywalls Clean` filterlist.
 
 4) **[Bypass Paywalls Clean filter](https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters)** | [add](https://gitlab.com/magnolia1234/bypass-paywalls-clean-filters/-/raw/main/bpc-paywall-filter.txt)

--- a/privacy_essentials.txt
+++ b/privacy_essentials.txt
@@ -1,7 +1,7 @@
 [Adblock Plus 2.0]
 ! Title: 🔒 Privacy Essentials
 ! Description: A curated list for advanced hardening. Minimize connections to third-party sites.
-! Updated: 1 December 2022
+! Updated: 7 December 2022
 ! License: https://creativecommons.org/licenses/by/3.0
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 7 days (update frequency)

--- a/privacy_essentials.txt
+++ b/privacy_essentials.txt
@@ -100,7 +100,7 @@ $ping
 ||datadoghq.com^
 ||decacopy.com^
 ||delvenetworks.com^$3p,script
-||discord.com^$3p
+||discord.com^$3p,doamin=~discohook.org
 ||discordapp.com^$3p,domain=~discord.com
 ||disqus.com^$3p
 ||disquscdn.com^$3p


### PR DESCRIPTION
`discohook.org` needs `discord.com` to send webhook messages on discord