### PR TITLE
Hide horizontal scrollbar on YouTube in fullscreen mode

### DIFF
--- a/personal.txt
+++ b/personal.txt
@@ -107,3 +107,9 @@ www.youtube.com##.ytd-comments-header-renderer.style-scope.count-text
 
 ! Hide Verified checkmark
 www.youtube.com##.ytd-badge-supported-renderer.style-scope.badge-style-type-verified.badge
+
+! Hide vertical scrollbar. This is only shown on Firefox (version 86 and above)
+! YouTube automatically resets `--ytd-app-fullerscreen-scrollbar-width` to `0px` when entering fullscreen, so the `:watch-attr(style)` operator is necessary.
+!#if env_firefox
+www.youtube.com##ytd-app:watch-attr(style):style(--ytd-app-fullerscreen-scrollbar-width: -1px !important;)
+!#endif

--- a/personal.txt
+++ b/personal.txt
@@ -3,7 +3,7 @@
 ! Description: Filters I use myself but may cause unintended effects of other users. Mostly peculiar YouTube filters.
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 7 days (update frequency)
-! Version: 18 October 2023
+! Version: 19 October 2023
 ! Syntax: AdBlock
 
 ! EDU

--- a/personal.txt
+++ b/personal.txt
@@ -108,8 +108,9 @@ www.youtube.com##.ytd-comments-header-renderer.style-scope.count-text
 ! Hide Verified checkmark
 www.youtube.com##.ytd-badge-supported-renderer.style-scope.badge-style-type-verified.badge
 
-! Hide vertical scrollbar. This is only shown on Firefox (version 86 and above)
+! Hide horizontal scrollbar. This is only shown on Firefox (version 86 and above)
 ! YouTube automatically resets `--ytd-app-fullerscreen-scrollbar-width` to `0px` when entering fullscreen, so the `:watch-attr(style)` operator is necessary.
+! https://github.com/yokoffing/filterlists/pull/109
 !#if env_firefox
 www.youtube.com##ytd-app:watch-attr(style):style(--ytd-app-fullerscreen-scrollbar-width: -1px !important;)
 !#endif


### PR DESCRIPTION
When a video is fullscreened, an unwanted and unnecessary *vertical* scrollbar is shown on Firefox v86 and above (not to be confused with the horizontal scrollbar, which scrolls up and down and is on the right edge of the screen).

The vertical scrollbar serves no use in fullscreen, dragging it around does nothing.

I didn't think that this would be appropriate for the annoyance filter, so I added it to the personal one, since I couldn't think of a reason that someone could dislike this addition. In case I'm intruding your personal list, you can feel free to reject the PR.

This only occurs on firefox (for some reason).

See the attached image (the gray line at the bottom is the vertical scroll bar. It may look different for you, since I have a firefox theme applied.)

![vertscrollbar](https://github.com/yokoffing/filterlists/assets/63961221/a74abecc-8844-419c-a8ac-36955d71b4d2)
