### PR TITLE
Update "Hide Verified checkmark" filter

### DIFF
--- a/personal.txt
+++ b/personal.txt
@@ -106,4 +106,5 @@ www.youtube.com##.ytd-video-owner-renderer.style-scope > yt-button-shape
 www.youtube.com##.ytd-comments-header-renderer.style-scope.count-text
 
 ! Hide Verified checkmark
-www.youtube.com##.ytd-badge-supported-renderer.style-scope.badge-style-type-verified.badge
+www.youtube.com##.ytd-comment-renderer #author-text:remove-attr(hidden)
+www.youtube.com##.ytd-comment-renderer #author-comment-badge


### PR DESCRIPTION
The old filter is outdated, and no longer works.
The new UI makes verified users' name a "badge", instead a plain "h3" header.

Fortunately, the h3 header is still present. It just has a "hidden" attribute assigned. The new filter removes the hidden attribute from the h3, and hides the badge.