### PR TITLE
Hide the leading seperator as well in the "Hide View count on Home, ..." filter

### DIFF
--- a/personal.txt
+++ b/personal.txt
@@ -53,8 +53,8 @@ www.youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:co
 ! www.youtube.com##ytd-rich-grid-renderer:style(--ytd-rich-grid-items-per-row: 4 !important;)
 
 ! Hide View count on Home, Subscriptions, etc.
-www.youtube.com###span.ytd-grid-video-renderer.style-scope:nth-of-type(1)
 www.youtube.com##span.ytd-video-meta-block.style-scope.inline-metadata-item:nth-of-type(1)
+www.youtube.com##span.ytd-video-meta-block.style-scope.inline-metadata-item:nth-of-type(2)::before
 
 ! Hide upload time (+ view count) under video player
 ! www.youtube.com###metadata-line

--- a/personal.txt
+++ b/personal.txt
@@ -53,8 +53,10 @@ www.youtube.com##ytd-rich-grid-row, #contents.ytd-rich-grid-row:style(display:co
 ! www.youtube.com##ytd-rich-grid-renderer:style(--ytd-rich-grid-items-per-row: 4 !important;)
 
 ! Hide View count on Home, Subscriptions, etc.
+! https://github.com/yokoffing/filterlists/pull/111
 www.youtube.com##span.ytd-video-meta-block.style-scope.inline-metadata-item:nth-of-type(1)
 www.youtube.com##span.ytd-video-meta-block.style-scope.inline-metadata-item:nth-of-type(2)::before
+! www.youtube.com###span.ytd-grid-video-renderer.style-scope:nth-of-type(1)
 
 ! Hide upload time (+ view count) under video player
 ! www.youtube.com###metadata-line


### PR DESCRIPTION
Currently, the filter only hides the view count element. The element that follows it, i.e., the date, has a leading seperator dot ("•"), which seperates the view count and the date. Since the view count is removed, that seperator is redundant and clutters up the UI.

Additionally, it seems like the `www.youtube.com###span.ytd-grid-video-renderer.style-scope:nth-of-type(1)` filter seems redundant, as there doesn't seem to be element that is removed by it, neither in subscriptions nor in the homepage. So I've removed it. If I'm wrong, then feel free to correct me and I'll accordingly revert the removal of that filter.