### PR TITLE
Address an oversight in the hide horizontal scrollbar filter

### DIFF
--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -3,7 +3,7 @@
 ! Description: Clean up YouTube clutter
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 7 days (update frequency)
-! Version: 19 October 2023e
+! Version: 21 October 2023
 ! Syntax: AdBlock
 
 ! Hide Like count to match Dislike
@@ -56,6 +56,7 @@ youtube.com##.ytp-quality-menu .ytp-menuitem:has(.ytp-premium-label)
 
 ! Hide horizontal scrollbar. This is only shown on Firefox (version 86 and above)
 ! https://github.com/yokoffing/filterlists/pull/109
+! https://github.com/yokoffing/filterlists/pull/112
 !#if env_firefox
 www.youtube.com##ytd-app:style(--ytd-app-fullerscreen-scrollbar-width: -1px !important;)
 !#endif

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -55,10 +55,9 @@ youtube.com##.ytp-quality-menu .ytp-menuitem:has(.ytp-premium-label)
 !#endif
 
 ! Hide horizontal scrollbar. This is only shown on Firefox (version 86 and above)
-! YouTube automatically resets `--ytd-app-fullerscreen-scrollbar-width` to `0px` when entering fullscreen, so the `:watch-attr(style)` operator is necessary.
 ! https://github.com/yokoffing/filterlists/pull/109
 !#if env_firefox
-www.youtube.com##ytd-app:watch-attr(style):style(--ytd-app-fullerscreen-scrollbar-width: -1px !important;)
+www.youtube.com##ytd-app:style(--ytd-app-fullerscreen-scrollbar-width: -1px !important;)
 !#endif
 
 ! Hide Verified checkmark


### PR DESCRIPTION
While originally writing the filter, I assumed that uBO overwrites the style tag of the element to apply css, so I used :watch-attr() so that uBO makes sure that it is set to -1px even when youtube resets it. 

However, as it turns out, uBO doesn't overwrite the style tag. It instead adds some gibberish attributes to the element and uses that as a selector and injects the css for that selector. Since my css already has `!important`, it takes more specificity than youtube's css in the style tag. So, the :watch-attr() operator is useless.