### PR TITLE
Prevent stats from live-updating

### DIFF
--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -3,7 +3,7 @@
 ! Description: Clean up YouTube clutter
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 7 days (update frequency)
-! Version: 22 October 2023
+! Version: 27 October 2023
 ! Syntax: AdBlock
 
 ! Hide Like count to match Dislike (attempt)
@@ -65,6 +65,10 @@ www.youtube.com##ytd-app:style(--ytd-app-fullerscreen-scrollbar-width: -1px !imp
 www.youtube.com##.ytd-badge-supported-renderer.style-scope.badge-style-type-verified.badge
 www.youtube.com##.ytd-comment-renderer #author-text:remove-attr(hidden)
 www.youtube.com##.ytd-comment-renderer #author-comment-badge
+
+! https://github.com/yokoffing/filterlists/pull/112
+! Prevent stats from live-updating
+||youtube.com/youtubei/v1/updated_metadata
 
 !!! UNUSED
 

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -66,8 +66,8 @@ www.youtube.com##.ytd-badge-supported-renderer.style-scope.badge-style-type-veri
 www.youtube.com##.ytd-comment-renderer #author-text:remove-attr(hidden)
 www.youtube.com##.ytd-comment-renderer #author-comment-badge
 
-! https://github.com/yokoffing/filterlists/pull/113
 ! Prevent stats from live-updating
+! https://github.com/yokoffing/filterlists/pull/113
 ||youtube.com/youtubei/v1/updated_metadata
 
 !!! UNUSED
@@ -75,15 +75,9 @@ www.youtube.com##.ytd-comment-renderer #author-comment-badge
 ! Hide recommendation sidebar
 ! www.youtube.com##ytd-watch-next-secondary-results-renderer.ytd-watch-flexy.style-scope
 
-! Hide next video, which may accidentally be clicked since it's near the Play button
-! www.youtube.com##.ytp-button.ytp-next-button
-
-! Video annotations; Hide the end screen video that autoplays next
+! Hide video annotations
 ! Block once for all the scripts responsible for annotations:
 ! /annotations_module.js$script,important,domain=youtube.com
-! and/or the end screen / auto play next:
-! /endscreen.js$script,important,domain=youtube.com
 
-! Subscriptions tab - Remove all vids shorter than 2 minutes
-! https://www.reddit.com/r/uBlockOrigin/comments/nz3hui/comment/h1tt25l/
-! [ALTERNATIVE] use "Enhancer for YouTube" to Convert Shorts
+! Hide the end screen video that autoplays next video
+! /endscreen.js$script,important,domain=youtube.com

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -66,7 +66,7 @@ www.youtube.com##.ytd-badge-supported-renderer.style-scope.badge-style-type-veri
 www.youtube.com##.ytd-comment-renderer #author-text:remove-attr(hidden)
 www.youtube.com##.ytd-comment-renderer #author-comment-badge
 
-! https://github.com/yokoffing/filterlists/pull/112
+! https://github.com/yokoffing/filterlists/pull/113
 ! Prevent stats from live-updating
 ||youtube.com/youtubei/v1/updated_metadata
 


### PR DESCRIPTION
Recently, YouTube recieved a UI update and now stats like the like count and view count automatically live-update under the video player. You can see how it looks like [here](https://www.reddit.com/r/youtube/comments/15c7ndi/youtube_has_added_live_updating_view_counts/). It is quite distracting, especially because it has an animation.
This PR stops stats from live updating, by blocking the endpoint from which the updated stats are fetched.