### PR TITLE
[youtube_clear_view] Hide badges under video recommendations

### DIFF
--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -66,6 +66,10 @@ www.youtube.com##.ytd-badge-supported-renderer.style-scope.badge-style-type-veri
 www.youtube.com##.ytd-comment-renderer #author-text:remove-attr(hidden)
 www.youtube.com##.ytd-comment-renderer #author-comment-badge
 
+! Hide badges (such as "New") under video recommendations on the sidebar
+! https://github.com/yokoffing/filterlists/pull/114
+www.youtube.com##ytd-video-meta-block + ytd-badge-supported-renderer
+
 ! Prevent stats from live-updating
 ! https://github.com/yokoffing/filterlists/pull/113
 ||youtube.com/youtubei/v1/updated_metadata

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -3,7 +3,7 @@
 ! Description: Clean up YouTube clutter
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 7 days (update frequency)
-! Version: 27 October 2023
+! Version: 29 October 2023
 ! Syntax: AdBlock
 
 ! Hide Like count to match Dislike (attempt)


### PR DESCRIPTION
Hide badges (such as "New") under video recommendations on the sidebar.

At first, I was going to only remove the "New" badge under videos, but now that I think about it, the badges only clutter up the UI. You can see all of the badges (such as "Fundraiser") under the video player, so there's no need for it under the video recommendations, and using `:has-text()` (which is a procedural filter, i.e. it uses javascript) to only target the "New" badge will make it less efficient as well.