### PR TITLE
Hide shorts shelf in description

### DIFF
--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -22,6 +22,9 @@ m.youtube.com##ytm-slim-video-action-bar-renderer ytm-button-renderer div[class$
 ! Hide chat window when viewing streams
 www.youtube.com###chat:remove()
 
+! Hide "Shorts remixing this video" shelf in the description
+www.youtube.com##ytd-reel-shelf-renderer
+
 ! Don't enter / exit fullscreen on double-click 
 www.youtube.com##+js(aeld, dblclick)
 

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -2,14 +2,9 @@
 ! Title: 📺 YouTube Clear View
 ! Description: Clean up YouTube clutter
 ! Homepage: https://github.com/yokoffing/filterlists
-! Expires: 7 days (update frequency)
-! Version: 29 October 2023
+! Expires: 4 days (update frequency)
+! Version: 3 November 2023
 ! Syntax: AdBlock
-
-! Hide Like count to match Dislike (attempt)
-! https://www.reddit.com/r/uBlockOrigin/comments/175xz51/comment/k4lfr4o/
-youtube.com##.YtLikeButtonViewModelHost .yt-spec-button-shape-next__button-text-content
-youtube.com##.YtLikeButtonViewModelHost .yt-spec-button-shape-next__icon:style(margin: 0 !important)
 
 ! Hide the text label of the dislike/share/download/report/save buttons
 ! new format June 2023


### PR DESCRIPTION
In some videos, above the transcripts section in the description, a shorts section is shown.

The content highlighted in red is removed by this filter.

![image](https://github.com/yokoffing/filterlists/assets/63961221/010e63fd-9c0f-45a1-8c5a-aeef93a44e94)