### PR TITLE
[youtube_clear_view] Hide new "smartimation" animations

### DIFF
--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -68,7 +68,8 @@ www.youtube.com##.ytd-comment-renderer #author-comment-badge
 ! https://github.com/yokoffing/filterlists/pull/114
 www.youtube.com##ytd-video-meta-block + ytd-badge-supported-renderer
 
-! Hide "smartimation" animations. Example: https://www.reddit.com/r/youtube/comments/15ri8fp/the_subscribe_button_now_plays_an_animation_when/
+! Hide "smartimation" animations
+! Hide the rainbow-colored border animation around the subscribe button
 ! https://github.com/yokoffing/filterlists/pull/117
 www.youtube.com##yt-smartimation > *:not(.smartimation__content)
 

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -3,7 +3,7 @@
 ! Description: Clean up YouTube clutter
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 3 November 2023
+! Version: 6 November 2023
 ! Syntax: AdBlock
 
 ! Hide the text label of the dislike/share/download/report/save buttons
@@ -67,6 +67,10 @@ www.youtube.com##.ytd-comment-renderer #author-comment-badge
 ! Hide badges (such as "New") under video recommendations on the sidebar
 ! https://github.com/yokoffing/filterlists/pull/114
 www.youtube.com##ytd-video-meta-block + ytd-badge-supported-renderer
+
+! Hide "smartimation" animations. Example: https://www.reddit.com/r/youtube/comments/15ri8fp/the_subscribe_button_now_plays_an_animation_when/
+! https://github.com/yokoffing/filterlists/pull/117
+www.youtube.com##yt-smartimation > *:not(.smartimation__content)
 
 ! Prevent stats from live-updating
 ! https://github.com/yokoffing/filterlists/pull/113


### PR DESCRIPTION
Example: https://www.youtube.com/watch?v=l_LsO3I_41M&t=11s
At 0:12, the subscribe button will have a rainbow-colored border animation around it for about a second.
Whenever someone says "subscribe", or "like" in the video, the respective elements get this animation. As you can tell, it is annoying unnecessary and distracting. For more info, see [this reddit thread](https://www.reddit.com/r/youtube/comments/15ri8fp/the_subscribe_button_now_plays_an_animation_when/)

The filter removes everything in the `yt-smartimation` element except than the content itself, i.e., removing the animation.

This can also be handled by setting some experiment flags, which are checked for in YouTube's `desktop_polymer_enable_wil_icons.js` script:
```
www.youtube.com##+js(set, yt.config_.EXPERIMENT_FLAGS.web_smartimations_killswitch, true)
www.youtube.com##+js(set, yt.config_.EXPERIMENT_FLAGS.register_web_smartimations_component, false)
```

But these may be removed at any point, so I went for the manual approach.