### PR TITLE
Remove youtube delay fix

### DIFF
--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -3,7 +3,7 @@
 ! Description: Clean up YouTube clutter
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 21 November 2023
+! Version: 18 December 2023
 ! Syntax: AdBlock
 
 ! Hide the text label of the dislike/share/download/report/save buttons

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -77,12 +77,6 @@ www.youtube.com##yt-smartimation > *:not(.smartimation__content)
 ! https://github.com/yokoffing/filterlists/pull/113
 ||youtube.com/youtubei/v1/updated_metadata
 
-! YouTube delay on Firefox
-! https://www.ghacks.net/2023/11/20/youtube-video-loading-delayed-fix-inside/
-!#if env_firefox
-www.youtube.com##+js(nano-stb, resolve(1), 5000, 0.001)
-!#endif
-
 !!! UNUSED
 
 ! Hide recommendation sidebar


### PR DESCRIPTION
A few reasons for this proposal:

* YouTube's detection mechanisms are rapidly changing. If you add filters related to detection/slowdowns/etc to your lists, it will only increase burden for uBO volunteers as they have to tell users to disable your list if it's causing a breakage/detection.

* Your source for the filters is ghacks, despite the fact that the filters from that article are actually outdated. The latest slowdown fix filters are in the [YouTube issue in the uAssets repo](https://github.com/uBlockOrigin/uAssets/issues/20586).

* The filter checks if firefox is active, which is misleading since the slowdown happens on all browsers, it's just that only some specific users have it.

