### PR TITLE
add exception oldgoogle.neocities.org

### DIFF
--- a/privacy_essentials.txt
+++ b/privacy_essentials.txt
@@ -375,7 +375,7 @@ fmovies.*##+js(nosiif, try)
 ||firebaseinstallations.googleapis.com^
 ||google-analytics.com^$3p,important
 ||google.com/cse/cse.js^
-||google.com^$3p,domain=~abc.xyz|~blackdog.ie|~cbsnews.com|~chromium.org|~developer.android.com|~flippity.net|~gstatic.com|~gptgo.ai|~nest.com|~translate.google.com|~youtube-nocookie.com|~youtube.com|~youtube.googleapis.com
+||google.com^$3p,domain=~abc.xyz|~blackdog.ie|~cbsnews.com|~chromium.org|~developer.android.com|~flippity.net|~gstatic.com|~gptgo.ai|~nest.com|~oldgoogle.neocities.org|~translate.google.com|~youtube-nocookie.com|~youtube.com|~youtube.googleapis.com
 ||googleadservices.com^$3p,important
 ||googlesyndication.com^$important
 ||googletagmanager.com^$important

--- a/privacy_essentials.txt
+++ b/privacy_essentials.txt
@@ -3,7 +3,7 @@
 ! Description: A curated list for advanced hardening. Minimize connections to third-party sites.
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 day (update frequency)
-! Version: 19 January 2024
+! Version: 22 January 2024
 ! Syntax: AdBlock
 
 ! GENERAL BLOCKLIST


### PR DESCRIPTION
causes breakage
test link: `https://oldgoogle.neocities.org/2010/search/?sclient=psy&hl=en&site=webhp&source=hp&q=test&btnG=Search`