### PR TITLE
Unbreak The Guardian YouTube Video Playback

### DIFF
--- a/click2load.txt
+++ b/click2load.txt
@@ -3,7 +3,7 @@
 ! Description: To be used in uBlock Origin
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 7 days (update frequency)
-! Version: 21 October 2024
+! Version: 23 December 2024
 ! Syntax: AdBlock
 
 !#if ext_ublock
@@ -63,6 +63,7 @@
 ||w.soundcloud.com/player/$3p,frame,redirect=click2load.html
 !||youtube-nocookie.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ||youtube-nocookie.com/embed^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
+! https://github.com/yokoffing/filterlists/pull/167
 ||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv|~www.theguardian.com
 ! https://github.com/yokoffing/filterlists/issues/161
 ||vk.com/video_ext$3p,frame,redirect=click2load.html

--- a/click2load.txt
+++ b/click2load.txt
@@ -63,7 +63,7 @@
 ||w.soundcloud.com/player/$3p,frame,redirect=click2load.html
 !||youtube-nocookie.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ||youtube-nocookie.com/embed^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
-||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv
+||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv|~www.theguardian.com
 ! https://github.com/yokoffing/filterlists/issues/161
 ||vk.com/video_ext$3p,frame,redirect=click2load.html
 ||rutube.ru/play/embed/$3p,frame,redirect=click2load.html


### PR DESCRIPTION
Without this exception, YouTube videos embedded in articles from The Guardian are simply stuck on a black screen and will not play.

Article as an example:

https://www.theguardian.com/us-news/2018/oct/22/donald-trump-ted-cruz-rally-houston-midterms-obama-vegas

This fixes it.