### PR TITLE
Fix cloudskillsboost.google & skills.google

### DIFF
--- a/block_third_party_fonts.txt
+++ b/block_third_party_fonts.txt
@@ -3,7 +3,7 @@
 ! Description: Block most third-party fonts. Allows for Material Icons and WOFF fonts in order to not break sites.
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 11 October 2024
+! Version: 23 December 2024
 ! Syntax: AdBlock
 
 !!! ALLOWLIST

--- a/block_third_party_fonts.txt
+++ b/block_third_party_fonts.txt
@@ -12,7 +12,7 @@
 @@||googleapis.com/ajax/libs/webfont/$domain=typepad.com
 @@||fast.fonts.net/jsapi/$script
 @@||fonts.googleapis.com$domain=abc.xyz|google.com|blog.google|blogger.com|browser.works|chromium.org|entertrained.app|freetaxusa.com|fmoviesz.to|gaggle.fun|googlesource.com|grow.google|groq.com|loanadministration.com|myeducator.com|nerdfonts.com|reedsy.com|reliaslearning.com|shop.flipperzero.one|socialworkers.org|googleapps.com|vocabulary.com|web.dev|youtube.com
-@@||fonts.gstatic.com$domain=about.google|ai.google|bloble.io|blog.google|blogger.com|cenreader.com|chrome.com|chromium.org|codingfont.com|dexscreener.com|entertrained.app|google.com|domains.google|googlesource.com|grow.google|groq.com|material.io|myeducator.com|nerdfonts.com|reedsy.com|reliaslearning.com|safety.google|socialworkers.org|toolbox.googleapps.com|vocabulary.com|web.dev|youtube.com
+@@||fonts.gstatic.com$domain=about.google|ai.google|bloble.io|blog.google|blogger.com|cenreader.com|chrome.com|chromium.org|cloudskillsboost.google|codingfont.com|dexscreener.com|entertrained.app|google.com|domains.google|googlesource.com|grow.google|groq.com|material.io|myeducator.com|nerdfonts.com|reedsy.com|reliaslearning.com|safety.google|skills.google|socialworkers.org|toolbox.googleapps.com|vocabulary.com|web.dev|youtube.com
 @@||googleusercontent.com/static/fonts/$domain=tudocelular.com
 @@||myfonts.net$domain=myfonts.com
 @@||typekit.com$font


### PR DESCRIPTION
Unfortunately, fonts are broken on these domains without `fonts.gstatic.com` being allowed.

Ex. [`cloudskillsboost.google`](https://cloudskillsboost.google):
![cloudskillsboost.google](https://github.com/user-attachments/assets/f38c413c-a0d7-4f87-b596-60c8ae1cb4b0)

& [`career.skills.google`](https://career.skills.google):
![career.skills.google](https://github.com/user-attachments/assets/363e7359-ed17-4c2b-9508-16d616898669)



