### PR TITLE
Fix plex.tv

### DIFF
--- a/block_third_party_fonts.txt
+++ b/block_third_party_fonts.txt
@@ -3,12 +3,12 @@
 ! Description: Block most third-party fonts. Allows for Material Icons and WOFF fonts in order to not break sites.
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 23 December 2024
+! Version: 24 December 2024
 ! Syntax: AdBlock
 
 !!! ALLOWLIST
 @@||ajax.googleapis.com/ajax/libs/webfont/$script,domain=bootsnipp.com|regexpal.com|typepad.com
-@@||amazonaws.com^$font,3p,domain=dollartree.com
+@@||amazonaws.com^$font,3p,domain=dollartree.com|plex.tv
 @@||googleapis.com/ajax/libs/webfont/$domain=typepad.com
 @@||fast.fonts.net/jsapi/$script
 @@||fonts.googleapis.com$domain=abc.xyz|google.com|blog.google|blogger.com|browser.works|chromium.org|entertrained.app|freetaxusa.com|fmoviesz.to|gaggle.fun|googlesource.com|grow.google|groq.com|loanadministration.com|myeducator.com|nerdfonts.com|reedsy.com|reliaslearning.com|shop.flipperzero.one|socialworkers.org|googleapps.com|vocabulary.com|web.dev|youtube.com


### PR DESCRIPTION
Certain icons on Plex are broken without allowing fonts from `amazonaws.com` - most notably when attempting to edit a library.

Ex. before this fix:

![before](https://github.com/user-attachments/assets/b8144e5a-78ef-49cf-9597-9d5cccd44a76)

After:

![after](https://github.com/user-attachments/assets/8cdad0d8-3ea0-4d92-898e-8e54722e2ec1)
