### PR TITLE
Fix Songsterr Youtube Playback

### DIFF
--- a/click2load.txt
+++ b/click2load.txt
@@ -66,7 +66,7 @@
 ||youtube-nocookie.com/embed^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ! https://github.com/yokoffing/filterlists/pull/167
 ! https://github.com/yokoffing/filterlists/pull/193
-||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv|~www.theguardian.com|~www.songsterr.com
+||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv|~theguardian.com|~songsterr.com
 ! https://github.com/yokoffing/filterlists/issues/161
 ||vk.com/video_ext$3p,frame,redirect=click2load.html
 ||rutube.ru/play/embed/$3p,frame,redirect=click2load.html

--- a/click2load.txt
+++ b/click2load.txt
@@ -65,7 +65,7 @@
 !||youtube-nocookie.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ||youtube-nocookie.com/embed^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ! https://github.com/yokoffing/filterlists/pull/167
-||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv|~www.theguardian.com
+||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv|~www.theguardian.com|~www.songsterr.com
 ! https://github.com/yokoffing/filterlists/issues/161
 ||vk.com/video_ext$3p,frame,redirect=click2load.html
 ||rutube.ru/play/embed/$3p,frame,redirect=click2load.html

--- a/click2load.txt
+++ b/click2load.txt
@@ -3,7 +3,7 @@
 ! Description: To be used in uBlock Origin
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 7 days (update frequency)
-! Version: 18 February 2025
+! Version: 18 March 2025
 ! Syntax: AdBlock
 
 !#if ext_ublock
@@ -65,6 +65,7 @@
 !||youtube-nocookie.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ||youtube-nocookie.com/embed^$3p,frame,redirect=click2load.html,domain=~bing.com|~google.com|~duckduckgo.com|~video.search.yahoo.com
 ! https://github.com/yokoffing/filterlists/pull/167
+! https://github.com/yokoffing/filterlists/pull/193
 ||youtube.com^$3p,frame,redirect=click2load.html,domain=~bing.com|~chatreplay.stream|~google.com|~duckduckgo.com|~video.search.yahoo.com|~w2g.tv|~www.theguardian.com|~www.songsterr.com
 ! https://github.com/yokoffing/filterlists/issues/161
 ||vk.com/video_ext$3p,frame,redirect=click2load.html


### PR DESCRIPTION
This exception fixes automatic YouTube playback when you press the play button on a song.

Example:
Just click the YouTube play icon at the bottom, and wait. The video will never play because the click2load prompt is hidden.
https://www.songsterr.com/a/wsa/metallica-master-of-puppets-tab-s455118