### PR TITLE
Unblock GPay on Amtrak to fix checkout breakage

### DIFF
--- a/privacy_essentials.txt
+++ b/privacy_essentials.txt
@@ -3,7 +3,7 @@
 ! Description: An opinionated list for advanced hardening. Minimize connections to third-party sites.
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 1 September 2025
+! Version: 26 December 2025
 ! Syntax: AdBlock
 
 ! GENERAL BLOCKLIST


### PR DESCRIPTION
Add an exception to the [Privacy Essentials](https://github.com/yokoffing/filterlists/blob/main/privacy_essentials.txt) rule blocking third-party requests to `pay.google.com` (in particular, `https://pay.google.com/gp/p/js/pay.js`) in order to allow the credit card / payment form to appear in the Amtrak checkout flow (`https://www.amtrak.com/tickets/payment.html`).

https://github.com/yokoffing/filterlists/blob/9f4349233acc19a56d3ce7c06e82a243e8cfc2ca/privacy_essentials.txt#L520