### PR TITLE
Enable CAPTCHA loading on Startpage

### DIFF
--- a/privacy_essentials.txt
+++ b/privacy_essentials.txt
@@ -287,6 +287,7 @@
 ||socialshopwave.com^$3p
 ||spot.im^$3p
 ||startpage.com/do/$image
+@@||startpage.com/do/captcha$image
 ||startpage.com/english/$image
 ||startpage.com/tst2/$image
 ||storage.ko-fi.com^$3p

--- a/privacy_essentials.txt
+++ b/privacy_essentials.txt
@@ -3,7 +3,7 @@
 ! Description: An opinionated list for advanced hardening. Minimize connections to third-party sites.
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 26 December 2025
+! Version: 8 April 2026
 ! Syntax: AdBlock
 
 ! GENERAL BLOCKLIST


### PR DESCRIPTION
Add an exception to a rule pulled from [uBO-Deny.txt](https://github.com/crssi/BlockLists/blob/a57a49d3dc953cd8ce1424a539bbcacb9a59e1f9/uBO-Deny.txt) in [crssi/BlockLists](https://github.com/crssi/BlockLists). The [problematic source rule](https://github.com/crssi/BlockLists/blob/a57a49d3dc953cd8ce1424a539bbcacb9a59e1f9/uBO-Deny.txt#L121) blocks all image requests to `*.startpage.com/do/*`, and the exception unblocks image requests to `*.startpage.com/do/captcha*`.