### PR TITLE
Change Youtube smartimation content class

### DIFF
--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -65,7 +65,7 @@ www.youtube.com##ytd-video-meta-block + ytd-badge-supported-renderer
 ! Hide "smartimation" animations
 ! Hide the rainbow-colored border animation around the subscribe button
 ! https://github.com/yokoffing/filterlists/pull/117
-www.youtube.com##yt-smartimation > *:not(.smartimation__content)
+www.youtube.com##yt-smartimation > *:not(.ytSmartImationsContent)
 
 ! Prevent stats from live-updating
 ! https://github.com/yokoffing/filterlists/pull/113

--- a/youtube_clear_view.txt
+++ b/youtube_clear_view.txt
@@ -3,7 +3,7 @@
 ! Description: Clean up YouTube clutter
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 13 August 2025
+! Version: 14 May 2026
 ! Syntax: AdBlock
 
 ! Hide the text label of the dislike/share/download/report/save buttons


### PR DESCRIPTION
Youtube changed the class of the smartimation content from `smartimation__content` to `ytSmartImationsContent`, which broke the blocklist. This PR fixes that.