### PR TITLE
Avoid hiding MacRumors navigation bar

### DIFF
--- a/annoyance_list.txt
+++ b/annoyance_list.txt
@@ -60,7 +60,7 @@ forbes.com##.link-embed.color-body-border.color-body.embed-base
 citationmachine.net###--ucf-upload-widget-modal-container
 grammarist.com##.inside-right-sidebar, div.wp-block-column-is-layout-flow.is-layout-flow.wp-block-column
 tomshardware.com##.hawk-main-editorial-container
-macrumors.com##.noskim
+macrumors.com##div.noskim
 infoworld.com##h4, .end-note
 techreviewteam.com##.wp-widget-group__inner-blocks
 medium.com##.adm.adl.abi.m, .bg.adn.abg.adp

--- a/annoyance_list.txt
+++ b/annoyance_list.txt
@@ -3,7 +3,7 @@
 ! Description: Hide annoyances and extraneous page elements ("related articles", "read more", etc.) not covered by other lists
 ! Homepage: https://github.com/yokoffing/filterlists
 ! Expires: 4 days (update frequency)
-! Version: 16 May 2026b
+! Version: 30 May 2026
 ! Syntax: AdBlock
 
 form.jotform.com##.formFooter-wrapper


### PR DESCRIPTION
The rule `macrumors.com##.noskim` hides the navigation header as well as other annoyances:

```js
$$(".noskim")
Array(24) [ nav.navigation--OvbFtbNW.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, div.footer--2v61-WeP.front---xGV7W2m.noskim, … ]
```

The `<nav>` element should ideally not match the [filter rule](https://github.com/yokoffing/filterlists/blob/0abc4b032489ce5759a1afde658dbd5f61a236e0/annoyance_list.txt#L63). 

I worked around it locally by disabling the existing rule and replacing it with a `<div>`-specific version:

```
macrumors.com#@#.noskim
macrumors.com##div.noskim
```

There's probably a better way, I'm not too familiar with the filter syntax and this was the first thing that worked. Feel free to edit with another solution.